### PR TITLE
Array equality benchmarks

### DIFF
--- a/performance/__equals_memcmp/__equals_memcmp.d
+++ b/performance/__equals_memcmp/__equals_memcmp.d
@@ -1,0 +1,14 @@
+module __equals_memcmp;
+
+template GenTest(string Struct, string Size, string arr)
+{
+    const char[] GenTest = "void test" ~ Struct ~ '_' ~ Size ~ "Elems() { "
+        ~ "enum size = " ~ Size ~ ";"
+        ~ Struct ~ "[] a = new  "~ Struct ~ "[size];"
+        ~ Struct ~ "[] b = new  "~ Struct ~ "[size];"
+        ~ q{
+            // Before the change: lowered to `__equals`
+            // After the change: lowered to `memcmp`
+            assert(a == b);
+         } ~ " }";
+}

--- a/performance/_adEq2_equals/_adEq2_equals.d
+++ b/performance/_adEq2_equals/_adEq2_equals.d
@@ -1,0 +1,20 @@
+module _adEq2_equals;
+
+template GenTest(string Struct, string Size, string arr)
+{
+    const char[] GenTest = "void test" ~ Struct ~ '_' ~ Size ~ "Elems() { "
+        ~ "enum size = " ~ Size ~ ";"
+        ~ q{
+            class A {
+                double[size] d;
+                this() { d[] = 1.0; }
+            }
+            
+            A[size] a = new A[size];
+            A[size] b = new A[size];
+
+            // Before the change: lowered to `__adEq2`
+            // After the change: lowered to `__equals`
+            assert(a == b);
+        } ~ " }";
+}

--- a/performance/_adEq2_memcmp/_adEq2_memcmp.d
+++ b/performance/_adEq2_memcmp/_adEq2_memcmp.d
@@ -1,0 +1,14 @@
+module _adEq2_memcmp;
+
+template GenTest(string Struct, string Size, string arr)
+{
+    const char[] GenTest = "void test" ~ Struct ~ '_' ~ Size ~ "Elems() { "
+        ~ "enum size = " ~ Size ~ ";"
+        ~ Struct ~ "[size] a = new  "~ Struct ~ "[size];"
+        ~ Struct ~ "[size] b = new  "~ Struct ~ "[size];"
+        ~ q{
+            // Before the change: lowered to `__adEq2`
+            // After the change: lowered to `memcmp`
+            assert(a == b);
+         } ~ " }";
+}

--- a/performance/_d_class_cast/_d_class_cast.d
+++ b/performance/_d_class_cast/_d_class_cast.d
@@ -1,0 +1,18 @@
+module _d_class_cast;
+
+template GenTest(string Struct, string Size, string arr)
+{
+    const char[] GenTest = "void test" ~ Struct ~ '_' ~ Size ~ "Elems() { "
+        ~ "enum size = " ~ Size ~ ";"
+        ~ q{
+            class A {}
+            class B: A{}
+            class C: B{}
+            
+           A ac = new C();
+           for (auto cnt = 0; cnt < size; ++cnt)
+           {
+                B b = cast(B)ac;
+           }
+        } ~ " }";
+}

--- a/performance/_d_dynamic_cast/_d_dynamic_cast.d
+++ b/performance/_d_dynamic_cast/_d_dynamic_cast.d
@@ -1,0 +1,18 @@
+module _d_dynamic_cast;
+
+template GenTest(string Struct, string Size, string arr)
+{
+    const char[] GenTest = "void test" ~ Struct ~ '_' ~ Size ~ "Elems() { "
+        ~ "enum size = " ~ Size ~ ";"
+        ~ q{
+            interface I {}
+            class A {}
+            class B: A, I {}
+            
+           A ab = new B();
+           for (auto cnt = 0; cnt < size; ++cnt)
+           {
+                I i = cast(I)ab;
+           }
+        } ~ " }";
+}

--- a/performance/_d_interface_cast/_d_interface_cast.d
+++ b/performance/_d_interface_cast/_d_interface_cast.d
@@ -1,0 +1,18 @@
+module _d_interface_cast;
+
+template GenTest(string Struct, string Size, string arr)
+{
+    const char[] GenTest = "void test" ~ Struct ~ '_' ~ Size ~ "Elems() { "
+        ~ "enum size = " ~ Size ~ ";"
+        ~ q{
+            interface I1 {}
+            interface I2 {}
+            class A : I1, I2 {}
+            
+           I1 i1 = new A();
+           for (auto cnt = 0; cnt < size; ++cnt)
+           {
+                I2 i2 = cast(I2)i1;
+           }
+        } ~ " }";
+}

--- a/performance/_d_paint_cast/_d_paint_cast.d
+++ b/performance/_d_paint_cast/_d_paint_cast.d
@@ -1,0 +1,17 @@
+module _d_paint_cast;
+
+template GenTest(string Struct, string Size, string arr)
+{
+    const char[] GenTest = "void test" ~ Struct ~ '_' ~ Size ~ "Elems() { "
+        ~ "enum size = " ~ Size ~ ";"
+        ~ q{
+            class A {}
+            final class B: A{}
+            
+           A ab = new B();
+           for (auto cnt = 0; cnt < size; ++cnt)
+           {
+                B b = cast(B)ab;
+           }
+        } ~ " }";
+}

--- a/performance/array_benchmark.d
+++ b/performance/array_benchmark.d
@@ -6,7 +6,8 @@ import std.math : sqrt;
 import std.algorithm : reduce;
 
 enum hooks = ["_d_arrayctor", "_d_arrayappendT", "_d_arraycatT",
-    "_d_arraycatnTX", "_d_arrayassign", "_d_newarrayT", "_d_arraysetcapacity"];
+    "_d_arraycatnTX", "_d_arrayassign", "_d_newarrayT", "_d_arraysetcapacity",
+    "_d_dynamic_cast", "_d_paint_cast", "_d_class_cast", "_d_interface_cast"];
 
 static foreach (hook; hooks)
     mixin("version (" ~ hook ~ ") import " ~ hook ~ " : GenTest;");

--- a/performance/array_benchmark.d
+++ b/performance/array_benchmark.d
@@ -7,7 +7,8 @@ import std.algorithm : reduce;
 
 enum hooks = ["_d_arrayctor", "_d_arrayappendT", "_d_arraycatT",
     "_d_arraycatnTX", "_d_arrayassign", "_d_newarrayT", "_d_arraysetcapacity",
-    "_d_dynamic_cast", "_d_paint_cast", "_d_class_cast", "_d_interface_cast"];
+    "_d_dynamic_cast", "_d_paint_cast", "_d_class_cast", "_d_interface_cast",
+    "_adEq2_memcmp", "_adEq2_equals", "__equals_memcmp"];
 
 static foreach (hook; hooks)
     mixin("version (" ~ hook ~ ") import " ~ hook ~ " : GenTest;");

--- a/performance/run_benchmark.sh
+++ b/performance/run_benchmark.sh
@@ -14,6 +14,9 @@ HOOKS_TEMPLATE_COMMITS["_d_dynamic_cast"]="47c7321477ae8d97f881efa6a3de360da4f4a
 HOOKS_TEMPLATE_COMMITS["_d_paint_cast"]="9e7f0af277b7762efa6ae1a3a35a0b6cb7257d17"
 HOOKS_TEMPLATE_COMMITS["_d_class_cast"]="e0f222194cd412f71b2b4eabfef966f90849ce36"
 HOOKS_TEMPLATE_COMMITS["_d_interface_cast"]="6e8eb081cfa3cb58f1b308cb290ca8f364666cfd"
+HOOKS_TEMPLATE_COMMITS["_adEq2_equals"]="ad35200fe3bb6b7f6a9e08bd2d83bc4857cd441e"
+HOOKS_TEMPLATE_COMMITS["_adEq2_memcmp"]="ad35200fe3bb6b7f6a9e08bd2d83bc4857cd441e"
+HOOKS_TEMPLATE_COMMITS["__equals_memcmp"]="ad35200fe3bb6b7f6a9e08bd2d83bc4857cd441e"
 
 declare -A HOOKS_NON_TEMPLATE_COMMITS
 HOOKS_NON_TEMPLATE_COMMITS["_d_arraysetcapacity"]="master"
@@ -21,6 +24,9 @@ HOOKS_NON_TEMPLATE_COMMITS["_d_dynamic_cast"]="99a390f3c6bae3b30c469222a9846273d
 HOOKS_NON_TEMPLATE_COMMITS["_d_paint_cast"]="8762d1eaee42119269b82a1b1b7063c89c1e6a69"
 HOOKS_NON_TEMPLATE_COMMITS["_d_class_cast"]="d234a544f13ee7293fc8108a0aba29685ae1ac38"
 HOOKS_NON_TEMPLATE_COMMITS["_d_interface_cast"]="9f573c494acc38855027462bde162fabea9cf33f"
+HOOKS_NON_TEMPLATE_COMMITS["_adEq2_equals"]="e0cf19144f2afed531cc2f40eee7e051994d4e98"
+HOOKS_NON_TEMPLATE_COMMITS["_adEq2_memcmp"]="e0cf19144f2afed531cc2f40eee7e051994d4e98"
+HOOKS_NON_TEMPLATE_COMMITS["__equals_memcmp"]="e0cf19144f2afed531cc2f40eee7e051994d4e98"
 
 declare -A druntime_a_size
 declare -A phobos2_a_size


### PR DESCRIPTION
I have added some benchmarks for testing the array equality performance after the changes brought by dlang/dmd#21513.
The benchmarked cases are:
- `_adEq2` -> `__equals`
- `_adEq2` -> `memcmp`
- `__equals` -> `memcmp`

The rest of the cases should remain the same, thus not worth testing.