### PR TITLE
Add `_d_arrayliteralTX` benchmark

### DIFF
--- a/performance/_d_arrayliteralTX/_d_arrayliteralTX.d
+++ b/performance/_d_arrayliteralTX/_d_arrayliteralTX.d
@@ -1,0 +1,23 @@
+module _d_arrayliteralTX;
+
+template GenArray(size_t Size, string Initializer)
+{
+    enum GenArray = (){
+        string arr = "[";
+        static foreach (i; 0 .. Size)
+        {
+            arr ~= Initializer;
+            if (i < Size - 1)
+                arr ~= ",";
+        }
+        return arr ~ "]";
+    }();
+}
+
+template GenTest(string Struct, string Size, string arr)
+{
+    const char[] GenTest = "void test" ~ Struct ~ '_' ~ Size ~ "Elems() { "
+        ~ "import _d_arrayliteralTX : GenArray;"
+        ~ "auto arr = mixin(GenArray!(" ~ Size ~ ",\"" ~ arr ~ "\")); "
+        ~ " }";
+}

--- a/performance/array_benchmark.d
+++ b/performance/array_benchmark.d
@@ -8,7 +8,7 @@ import std.algorithm : reduce;
 enum hooks = ["_d_arrayctor", "_d_arrayappendT", "_d_arraycatT",
     "_d_arraycatnTX", "_d_arrayassign", "_d_newarrayT", "_d_arraysetcapacity",
     "_d_dynamic_cast", "_d_paint_cast", "_d_class_cast", "_d_interface_cast",
-    "_adEq2_memcmp", "_adEq2_equals", "__equals_memcmp"];
+    "_adEq2_memcmp", "_adEq2_equals", "__equals_memcmp", "_d_arrayliteralTX"];
 
 static foreach (hook; hooks)
     mixin("version (" ~ hook ~ ") import " ~ hook ~ " : GenTest;");

--- a/performance/run_benchmark.sh
+++ b/performance/run_benchmark.sh
@@ -17,6 +17,7 @@ HOOKS_TEMPLATE_COMMITS["_d_interface_cast"]="6e8eb081cfa3cb58f1b308cb290ca8f3646
 HOOKS_TEMPLATE_COMMITS["_adEq2_equals"]="ad35200fe3bb6b7f6a9e08bd2d83bc4857cd441e"
 HOOKS_TEMPLATE_COMMITS["_adEq2_memcmp"]="ad35200fe3bb6b7f6a9e08bd2d83bc4857cd441e"
 HOOKS_TEMPLATE_COMMITS["__equals_memcmp"]="ad35200fe3bb6b7f6a9e08bd2d83bc4857cd441e"
+HOOKS_TEMPLATE_COMMITS["_d_arrayliteralTX"]="c2c8189599b894771393100ceae1ca2da30202d0"
 
 declare -A HOOKS_NON_TEMPLATE_COMMITS
 HOOKS_NON_TEMPLATE_COMMITS["_d_arraysetcapacity"]="master"
@@ -27,6 +28,7 @@ HOOKS_NON_TEMPLATE_COMMITS["_d_interface_cast"]="9f573c494acc38855027462bde162fa
 HOOKS_NON_TEMPLATE_COMMITS["_adEq2_equals"]="e0cf19144f2afed531cc2f40eee7e051994d4e98"
 HOOKS_NON_TEMPLATE_COMMITS["_adEq2_memcmp"]="e0cf19144f2afed531cc2f40eee7e051994d4e98"
 HOOKS_NON_TEMPLATE_COMMITS["__equals_memcmp"]="e0cf19144f2afed531cc2f40eee7e051994d4e98"
+HOOKS_NON_TEMPLATE_COMMITS["_d_arrayliteralTX"]="9749967b599870b2fdeb2744a3003e5cddf16242"
 
 declare -A druntime_a_size
 declare -A phobos2_a_size


### PR DESCRIPTION
As in the title.

The test is also quite limited since there is a hard limit of how large a generated string can be when using this method (static foreach + template), so generation of larger array literals may fail. Any attempted walkaround led to either extremely high ram usage or weird address boundary segfaults in the compiler.