### PR TITLE
Add AA benchmarks

### DIFF
--- a/performance/_aaDel/_aaDel.d
+++ b/performance/_aaDel/_aaDel.d
@@ -1,0 +1,14 @@
+module _aaDel;
+
+template GenTest(string Struct, string Size, string arr)
+{
+    const char[] GenTest = "void test" ~ Struct ~ '_' ~ Size ~ "Elems() { "
+        ~ "import aa_utils : GenAA;"
+        ~ "enum size = " ~ Size ~ ";"
+        ~ "auto aa = mixin(GenAA!(" ~ Size ~ "));"
+        ~ q{
+            foreach (i; 0 .. size)
+                aa.remove(i);
+        }
+        ~ " }";
+}

--- a/performance/_aaDup/_aaDup.d
+++ b/performance/_aaDup/_aaDup.d
@@ -1,0 +1,10 @@
+module _aaDup;
+
+template GenTest(string Struct, string Size, string arr)
+{
+    const char[] GenTest = "void test" ~ Struct ~ '_' ~ Size ~ "Elems() { "
+        ~ "import aa_utils : GenAA;"
+        ~ "static const aa = mixin(GenAA!(" ~ Size ~ ", \"" ~ Struct ~ "()\"));"
+        ~ "auto aa_dup = aa.dup;"
+        ~ " }";
+}

--- a/performance/_aaEqual/_aaEqual.d
+++ b/performance/_aaEqual/_aaEqual.d
@@ -1,0 +1,14 @@
+module _aaEqual;
+
+template GenTest(string Struct, string Size, string arr)
+{
+    const char[] GenTest = "void test" ~ Struct ~ '_' ~ Size ~ "Elems() { "
+        ~ "import aa_utils : GenAA;"
+        ~ "enum aa_lit = GenAA!(" ~ Size ~ ", \"" ~ Struct ~ "()\");"
+        ~ q{
+          static const aa1 = mixin(aa_lit);
+          static const aa2 = mixin(aa_lit);
+          bool _ = aa1 == aa2;
+        }
+        ~ " }";
+}

--- a/performance/_aaGetHash/_aaGetHash.d
+++ b/performance/_aaGetHash/_aaGetHash.d
@@ -1,0 +1,10 @@
+module _aaGetHash;
+
+template GenTest(string Struct, string Size, string arr)
+{
+    const char[] GenTest = "void test" ~ Struct ~ '_' ~ Size ~ "Elems() { "
+        ~ "import aa_utils : GenAA;"
+        ~ "static const aa = mixin(GenAA!(" ~ Size ~ ", \"" ~ Struct ~ "()\"));"
+        ~ "auto hash = typeid(aa).getHash(&aa);"
+        ~ " }";
+}

--- a/performance/_aaGetX/_aaGetX.d
+++ b/performance/_aaGetX/_aaGetX.d
@@ -1,0 +1,14 @@
+module _aaGetX;
+
+template GenTest(string Struct, string Size, string arr)
+{
+    const char[] GenTest = "void test" ~ Struct ~ '_' ~ Size ~ "Elems() { "
+        ~ "import aa_utils : GenAA;"
+        ~ "enum size = " ~ Size ~ ";"
+        ~ "static aa = mixin(GenAA!(" ~ Size ~ "));"
+        ~ q{
+            foreach (i; 0 .. size)
+                aa.require(i, 0);
+        }
+        ~ " }";
+}

--- a/performance/_aaIn/_aaIn.d
+++ b/performance/_aaIn/_aaIn.d
@@ -1,0 +1,14 @@
+module _aaIn;
+
+template GenTest(string Struct, string Size, string arr)
+{
+    const char[] GenTest = "void test" ~ Struct ~ '_' ~ Size ~ "Elems() { "
+        ~ "import aa_utils : GenAA;"
+        ~ "enum size = " ~ Size ~ ";"
+        ~ "static const aa = mixin(GenAA!(" ~ Size ~ "));"
+        ~ q{
+            foreach (i; 0 .. size)
+                auto _ = i in aa;
+        }
+        ~ " }";
+}

--- a/performance/_aaKeys/_aaKeys.d
+++ b/performance/_aaKeys/_aaKeys.d
@@ -1,0 +1,10 @@
+module _aaKeys;
+
+template GenTest(string Struct, string Size, string arr)
+{
+    const char[] GenTest = "void test" ~ Struct ~ '_' ~ Size ~ "Elems() { "
+        ~ "import aa_utils : GenAA;"
+        ~ "static const aa = mixin(GenAA!(" ~ Size ~ "));"
+        ~ "auto keys = aa.keys;"
+        ~ " }";
+}

--- a/performance/_d_assocarrayliteralTX/_d_assocarrayliteralTX.d
+++ b/performance/_d_assocarrayliteralTX/_d_assocarrayliteralTX.d
@@ -1,0 +1,9 @@
+module _d_assocarrayliteralTX;
+
+template GenTest(string Struct, string Size, string arr)
+{
+    const char[] GenTest = "void test" ~ Struct ~ '_' ~ Size ~ "Elems() { "
+        ~ "import aa_utils : GenAA;"
+        ~ "auto aa = mixin(GenAA!(" ~ Size ~ ", \"" ~ Struct ~ "()\"));"
+        ~ " }";
+}

--- a/performance/aa_utils.d
+++ b/performance/aa_utils.d
@@ -1,0 +1,16 @@
+module aa_utils;
+
+template GenAA(size_t Size, string ValueInit = "0")
+{
+    import std.conv;
+    enum GenAA = (){
+        string arr = "[";
+        static foreach (i; 0 .. Size)
+        {
+            arr ~= i.to!string ~ ":" ~ ValueInit;
+            if (i < Size - 1)
+                arr ~= ",";
+        }
+        return arr ~ "]";
+    }();
+}

--- a/performance/array_benchmark.d
+++ b/performance/array_benchmark.d
@@ -8,7 +8,9 @@ import std.algorithm : reduce;
 enum hooks = ["_d_arrayctor", "_d_arrayappendT", "_d_arraycatT",
     "_d_arraycatnTX", "_d_arrayassign", "_d_newarrayT", "_d_arraysetcapacity",
     "_d_dynamic_cast", "_d_paint_cast", "_d_class_cast", "_d_interface_cast",
-    "_adEq2_memcmp", "_adEq2_equals", "__equals_memcmp"];
+    "_adEq2_memcmp", "_adEq2_equals", "__equals_memcmp",
+    "_aaGetHash", "_aaEqual", "_aaKeys", "_aaDel", "_aaIn", "_aaGetX", "_aaDup", "_d_assocarrayliteralTX",
+    ];
 
 static foreach (hook; hooks)
     mixin("version (" ~ hook ~ ") import " ~ hook ~ " : GenTest;");

--- a/performance/run_benchmark.sh
+++ b/performance/run_benchmark.sh
@@ -28,6 +28,12 @@ HOOKS_NON_TEMPLATE_COMMITS["_adEq2_equals"]="e0cf19144f2afed531cc2f40eee7e051994
 HOOKS_NON_TEMPLATE_COMMITS["_adEq2_memcmp"]="e0cf19144f2afed531cc2f40eee7e051994d4e98"
 HOOKS_NON_TEMPLATE_COMMITS["__equals_memcmp"]="e0cf19144f2afed531cc2f40eee7e051994d4e98"
 
+_aa_hooks=("_aaGetHash" "_aaEqual" "_aaKeys" "_aaDel" "_aaIn" "_aaGetX" "_aaDup" "_d_assocarrayliteralTX")
+for hook in "${_aa_hooks[@]}"; do
+	HOOKS_TEMPLATE_COMMITS[$hook]="d8a6f8761477f062c75d17707ad8c7d0ccb8598d"
+	HOOKS_NON_TEMPLATE_COMMITS[$hook]="941545f298c6f081577568f32a4905aa40571d29"
+done
+
 declare -A druntime_a_size
 declare -A phobos2_a_size
 declare -A phobos2_so_size


### PR DESCRIPTION
The implemented tests represent the slightly more relevant cases, where we could observe a real difference. Most of the tests make use of static variables to prevent interference from other AA hooks.

The commit hash for the templated hooks will be updated after Rainer's PR  will be merged.